### PR TITLE
Fixed set_hook() in the server.lua

### DIFF
--- a/http/server.lua
+++ b/http/server.lua
@@ -846,6 +846,7 @@ end
 local function set_hook(self, name, sub)
     if sub == nil or type(sub) == 'function' then
         self.hooks[ name ] = sub
+        return self
     end
     errorf("Wrong type for hook function: %s", type(sub))
 end


### PR DESCRIPTION
Added `return self` to the `set_hook()` function.