### PR TITLE
http 1.1.0 and http 2.0.1 compatibility

### DIFF
--- a/examples/middleware.lua
+++ b/examples/middleware.lua
@@ -13,7 +13,7 @@ local httpd = http_server.new('127.0.0.1', 12345, {
 })
 
 local function swap_orange_and_apple(env)
-    local path_info = env['PATH_INFO']
+    local path_info = env['path']
     log.info('swap_orange_and_apple: path_info = %s', path_info)
     if path_info == '/fruits/orange' then
         env['PATH_INFO'] = '/fruits/apple'

--- a/http-scm-1.rockspec
+++ b/http-scm-1.rockspec
@@ -12,6 +12,7 @@ description = {
 dependencies = {
     'lua >= 5.1',
     'checks >= 3.0.1',
+    'errors >= 2.1.2'
 }
 external_dependencies = {
     TARANTOOL = {

--- a/http/nginx_server/init.lua
+++ b/http/nginx_server/init.lua
@@ -54,12 +54,12 @@ local function make_env(server, req)
             rewind = tsgi_input_rewind,
         },
         ['tsgi.hijack'] = nil,            -- no support for hijack with nginx
-        ['REQUEST_METHOD'] = string.upper(req.method),
+        ['method'] = string.upper(req.method),
         ['SERVER_NAME'] = server.host,
         ['SERVER_PORT'] = server.port,
-        ['PATH_INFO'] = path_info,
-        ['QUERY_STRING'] = query_string,
-        ['SERVER_PROTOCOL'] = req.proto,
+        ['path'] = path_info,
+        ['query'] = query_string,
+        ['proto'] = req.proto,
         [tsgi.KEY_PEER] = {
             host = peer_host,
             port = peer_port,

--- a/http/router/fs.lua
+++ b/http/router/fs.lua
@@ -50,7 +50,7 @@ local function catfile(...)
 end
 
 local function static_file(self, request, format)
-    local file = catfile(self.options.app_dir, 'public', request:path())
+    local file = catfile(self.options.app_dir, 'public', request.path)
 
     if self.options.cache_static and self.cache.static[ file ] ~= nil then
         return {

--- a/http/router/init.lua
+++ b/http/router/init.lua
@@ -25,7 +25,7 @@ end
 
 local function main_endpoint_middleware(request)
     local self = request:router()
-    local format = uri_file_extension(request:path(), 'html')
+    local format = uri_file_extension(request.path, 'html')
     local r = request[tsgi.KEY_ROUTE]
 
     if r == nil then
@@ -39,8 +39,8 @@ end
 
 local function populate_chain_with_middleware(env, middleware_obj)
     local filter = matching.transform_filter({
-        path = env:path(),
-        method = env:method()
+        path = env.path,
+        method = env.method
     })
     for _, m in pairs(middleware_obj:ordered()) do
         if matching.matches(m, filter) then
@@ -52,7 +52,7 @@ end
 local function dispatch_middleware(req)
     local self = req:router()
 
-    local r = self:match(req:method(), req:path())
+    local r = self:match(req.method, req.path)
     req[tsgi.KEY_ROUTE] = r
 
     populate_chain_with_middleware(req, self.middleware)

--- a/http/router/request.lua
+++ b/http/router/request.lua
@@ -39,24 +39,24 @@ local function request_tostring(self)
 end
 
 local function request_line(self)
-    local rstr = self:path()
+    local rstr = self.path
 
-    local query_string = self:query()
+    local query_string = self.query
     if  query_string ~= nil and query_string ~= '' then
         rstr = rstr .. '?' .. query_string
     end
 
     return utils.sprintf("%s %s %s",
-        self['REQUEST_METHOD'],
+        self.method,
         rstr,
         self['SERVER_PROTOCOL'] or 'HTTP/?')
 end
 
 local function query_param(self, name)
-    if self:query() ~= nil and string.len(self:query()) == 0 then
+    if self.query ~= nil and string.len(self.query) == 0 then
         rawset(self, 'query_params', {})
     else
-        local params = lib.params(self['QUERY_STRING'])
+        local params = lib.params(self.query)
         local pres = {}
         for k, v in pairs(params) do
             pres[ utils.uri_unescape(k) ] = utils.uri_unescape(v)
@@ -193,45 +193,9 @@ local function request_read_cached(self)
 end
 
 -------------------------------------
-local function request_peer(self)
-    return self[tsgi.KEY_PEER]
-end
-
-local function request_method(self)
-    return self['REQUEST_METHOD']
-end
-
-local function request_path(self)
-    return self['PATH_INFO']
-end
-
-local function request_query(self)
-    return self['QUERY_STRING']
-end
-
-local function request_proto(self)
-    -- parse SERVER_PROTOCOL which is 'HTTP/<maj>.<min>'
-    local maj = self['SERVER_PROTOCOL']:sub(-3, -3)
-    local min = self['SERVER_PROTOCOL']:sub(-1, -1)
-    return {
-        [1] = tonumber(maj),
-        [2] = tonumber(min),
-    }
-end
-
-local function request_headers(self)
-    local headers = {}
-    for name, value in pairs(tsgi.headers(self)) do
-        -- strip HEADER_ part and convert to lowercase
-        local converted_name = name:sub(8):lower()
-        headers[converted_name] = value
-    end
-    return headers
-end
 
 local function request_header(self, name)
-    name = 'HEADER_' .. name:upper()
-    return self[name]
+    return self.headers[name]
 end
 
 ----------------------------------
@@ -266,12 +230,6 @@ local metatable = {
         read        = request_read,
         json        = request_json,
 
-        peer        = request_peer,
-        method      = request_method,
-        path        = request_path,
-        query       = request_query,
-        proto       = request_proto,
-        headers     = request_headers,
         header      = request_header,
 
         next        = request_next,

--- a/http/server/init.lua
+++ b/http/server/init.lua
@@ -3,9 +3,11 @@ local tsgi_adapter = require('http.server.tsgi_adapter')
 local tsgi = require('http.tsgi')
 local lib = require('http.lib')
 local utils = require('http.utils')
+local http_router = require('http.router')
 
 local log = require('log')
 local socket = require('socket')
+local errors = require('errors')
 local errno = require('errno')
 
 local DETACHED = 101
@@ -316,6 +318,14 @@ local function httpd_router(self)
     return self.options.router
 end
 
+local function httpd_route(self, opts, handler)
+    errors.deprecate(
+        'Using http.server:route is deprecated, ' ..
+        'create http.router object and set it via http.server:set_router instead.'
+    )
+    self.options.router:route(opts, handler)
+end
+
 local new = function(host, port, options)
     if options == nil then
         options = {}
@@ -325,7 +335,7 @@ local new = function(host, port, options)
     end
 
     local default = {
-        router              = nil,   -- no router set-up initially
+        router              = http_router.new({}),   -- default router, using deprecated
         log_requests        = true,
         log_errors          = true,
         display_errors      = true,
@@ -340,6 +350,7 @@ local new = function(host, port, options)
         set_router = httpd_set_router,
         router     = httpd_router,
         options    = utils.extend(default, options, true),
+        route      = httpd_route,
     }
 
     return self

--- a/http/server/tsgi_adapter.lua
+++ b/http/server/tsgi_adapter.lua
@@ -66,6 +66,7 @@ local function make_env(opts)
         [tsgi.KEY_PARSED_REQUEST] = p,          -- TODO: delete?
         [tsgi.KEY_PEER] = opts.peer,            -- TODO: delete?
 
+        ['peer'] = opts.peer,
         ['tsgi.version'] = '1',
         ['tsgi.url_scheme'] = 'http',      -- no support for https yet
         ['tsgi.input'] = {
@@ -74,11 +75,14 @@ local function make_env(opts)
         },
 
         ['REQUEST_METHOD'] = p.method,
-        ['PATH_INFO'] = p.path,
-        ['QUERY_STRING'] = p.query,
+        ['method'] = p.method,
+        ['path'] = p.path,
+        ['query'] = p.query,
         ['SERVER_NAME'] = opts.httpd.host,
         ['SERVER_PORT'] = opts.httpd.port,
+        ['proto'] = p.proto,
         ['SERVER_PROTOCOL'] = string.format('HTTP/%d.%d', p.proto[1], p.proto[2]),
+        ['headers'] = p.headers,
     }
 
     -- Pass through `env` to env['tsgi.*']:*() functions

--- a/http/tsgi.lua
+++ b/http/tsgi.lua
@@ -30,14 +30,14 @@ local function serialize_request(env)
     -- TODO: copypaste from router/request.lua.
     -- maybe move it to tsgi.lua.
 
-    local res = env['PATH_INFO']
-    local query_string = env['QUERY_STRING']
+    local res = env.path
+    local query_string = env.query
     if query_string ~= nil and query_string ~= '' then
         res = res .. '?' .. query_string
     end
 
     res = utils.sprintf("%s %s %s",
-                        env['REQUEST_METHOD'],
+                        env.method,
                         res,
                         env['SERVER_PROTOCOL'] or 'HTTP/?')
     res = res .. "\r\n"

--- a/test/http_test.lua
+++ b/test/http_test.lua
@@ -321,6 +321,17 @@ g.test_request_headers = function()
     server:stop()
 end
 
+g.test_server_route = function()
+    local httpd = http_server.new('127.0.0.1', 12345, {
+        log_requests = true,
+        log_errors = true
+    })
+    httpd:start()
+    httpd:route({path = '/test', method = 'GET'}, function () return  {body = 'test'} end)
+    local r = http_client.get('http://127.0.0.1:12345/test')
+    t.assert_equals(r.body, 'test')
+    httpd:stop()
+end
 
 
 g.test_server_requests = function()


### PR DESCRIPTION
http v2 and http v1 are incompatible

List of incompatibilities:
* req:headers(), req:path(), req:peer(), req:method(), req:query(), req:proto() methods are table keys in http v1
* http.server in http v1 does't have http.server:route() method
* https://github.com/tarantool/frontend-core/issues/39

In this pr:
* request "getter methods" were replaced by table keys
* added http.server:route() method and marked as deprecated via errors rocks
