### PR TITLE
Fix routes overlapping by *any pattern in route's path

### DIFF
--- a/http/router/matching.lua
+++ b/http/router/matching.lua
@@ -57,7 +57,7 @@ local function transform_pattern(path)
         if string.match(match, '^.') ~= '/' then
             match = '/' .. match
         end
-        match = '^' .. match .. '$'
+        match = '^(' .. match .. ')$'
     end
 
     return match, stash
@@ -70,9 +70,14 @@ local function matches(r, filter)
     end
 
     local regex_groups_matched = {string.match(filter.path, r.match)}
+
     if #regex_groups_matched == 0 then
         return false
     end
+
+    -- first regex_group is whole path, we should omit it
+    table.remove(regex_groups_matched, 1)
+
     if #r.stash > 0 and #r.stash ~= #regex_groups_matched then
         return false
     end
@@ -86,7 +91,6 @@ local function matches(r, filter)
     return true, {
         route = r,
         stash = regex_groups_matched,
-
         -- the more symbols were known in advance by route,
         -- the more priority we give the route
         specificity = -symbols_didnt_know,

--- a/test/integration/router_test.lua
+++ b/test/integration/router_test.lua
@@ -16,6 +16,14 @@ g.after_each(function()
     g.server:stop()
 end)
 
+g.test_route_priority_any = function()
+    g.router:route({ path = 'test/*any', method = 'GET' }, function() return {body = 'any'} end)
+    t.assert_equals(http_client.get(helper.base_uri .. 'test/some').body, 'any')
+
+    g.router:route({ path = 'test/some', method = 'GET'}, function () return  {body = 'some'} end)
+    t.assert_equals(http_client.get(helper.base_uri .. 'test/some').body, 'some')
+end
+
 g.test_route_priority_stash = function()
     g.router:route({method = 'GET', path = '*stashname'}, function(_)
         return {


### PR DESCRIPTION
Closes #105 

The bug was in incorrect ``specificity`` counting. 
``specificity`` is a how many symbols were not known (were hidden behind : and * patterns) in route's path. ``specificity`` was calculated as negative sum of symbols in regex groups, which were created from route's path.

 ```lua
local regex_groups_matched = {string.match(filter.path, r.match)}
```

But if match pattern has not any regex groups and string matches,  string.match returns all string.

Example:

```lua
tarantool> string.match('test/some', '^test/(.-)$')
---
- some
...

tarantool> string.match('test/some', '^test/some$')
---
- test/some
...
```

So if request's path is the same as route's path then string.match will return whole and this route will get the lowest priority.

So we need to explicitly add regex group which covers all path and take this into account.

```lua
tarantool> string.match('test/some', '^(test/(.-))$')
---
- test/some
- some
... 