### PR TITLE
Added ability to set cookie without escaping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ end
 | `req:post_param(name)` | returns a single POST request a parameter value.  If `name` is `nil`, returns all parameters as a Lua table. |
 | `req:query_param(name)` | returns a single GET request parameter value.  If `name` is `nil`, returns a Lua table with all arguments. |
 | `req:param(name)` | any request parameter, either GET or POST. |
-| `req:cookie(name)` | to get a cookie in the request. |
+| `req:cookie(name, {raw = true})` | to get a cookie in the request. if `raw` option was set then cookie will not be unescaped, otherwise cookie's value will be unescaped |
 | `req:stash(name[, value])` | **NOTE**: currently not supported inside middleware handlers. Get or set a variable "stashed" when dispatching a route. |
 | `req:url_for(name, args, query)` | returns the route's exact URL.
 | `req:redirect_to` | create a **Response** object with an HTTP redirect.
@@ -221,7 +221,7 @@ end
 | `resp.status` | HTTP response code.
 | `resp.headers` | a Lua table with normalized headers.
 | `resp.body` | response body (string|table|wrapped\_iterator).
-| `resp:setcookie({ name = 'name', value = 'value', path = '/', expires = '+1y', domain = 'example.com'))` | adds `Set-Cookie` headers to `resp.headers`.
+| `resp:setcookie({ name = 'name', value = 'value', path = '/', expires = '+1y', domain = 'example.com'}, {raw = true})` | adds `Set-Cookie` headers to `resp.headers`, if `raw` option was set then cookie will not be escaped, otherwise cookie's value and path will be escaped
 
 ### Examples
 

--- a/http/router/request.lua
+++ b/http/router/request.lua
@@ -123,14 +123,19 @@ local function param(self, name)
     return utils.extend(post, query, false)
 end
 
-local function cookie(self, cookiename)
+local function cookie(self, cookiename, options)
+    options = options or {}
     if self:header('cookie') == nil then
         return nil
     end
     for k, v in string.gmatch(
         self:header('cookie'), "([^=,; \t]+)=([^,; \t]+)") do
         if k == cookiename then
-            return utils.uri_unescape(v)
+            if not options.raw then
+                return utils.uri_unescape(v)
+            else
+                return v
+            end
         end
     end
     return nil

--- a/http/utils.lua
+++ b/http/utils.lua
@@ -36,6 +36,14 @@ local function extend(tbl, tblu, raise)
     return res
 end
 
+local function escape_char(char)
+    return string.format('%%%02X', string.byte(char))
+end
+
+local function unescape_char(char)
+    return string.char(tonumber(char, 16))
+end
+
 local function uri_unescape(str, unescape_plus_sign)
     local res = {}
     if type(str) == 'table' then
@@ -47,11 +55,7 @@ local function uri_unescape(str, unescape_plus_sign)
             str = string.gsub(str, '+', ' ')
         end
 
-        res = string.gsub(str, '%%([0-9a-fA-F][0-9a-fA-F])',
-                          function(c)
-                              return string.char(tonumber(c, 16))
-                          end
-        )
+        res = string.gsub(str, '%%([0-9a-fA-F][0-9a-fA-F])', unescape_char)
     end
     return res
 end
@@ -63,11 +67,7 @@ local function uri_escape(str)
             table.insert(res, uri_escape(v))
         end
     else
-        res = string.gsub(str, '[^a-zA-Z0-9_]',
-                          function(c)
-                              return string.format('%%%02X', string.byte(c))
-                          end
-        )
+        res = string.gsub(str, '[^a-zA-Z0-9_]', escape_char)
     end
     return res
 end
@@ -80,4 +80,6 @@ return {
     extend = extend,
     uri_unescape = uri_unescape,
     uri_escape = uri_escape,
+    escape_char = escape_char,
+    unescape_char = unescape_char,
 }

--- a/test/unit/setcookie_test.lua
+++ b/test/unit/setcookie_test.lua
@@ -1,0 +1,176 @@
+local t = require('luatest')
+local g = t.group()
+
+local response = require('http.router.response')
+
+local function get_object()
+    return setmetatable({}, response.metatable)
+end
+
+g.test_values_escaping = function()
+    local test_table = {
+        whitespace = {
+            value = "f f",
+            result = 'f%20f',
+        },
+        dquote = {
+            value = 'f"f',
+            result = 'f%22f',
+        },
+        comma = {
+            value = "f,f",
+            result = "f%2Cf",
+        },
+        semicolon = {
+            value = "f;f",
+            result = "f%3Bf",
+        },
+        backslash = {
+            value = "f\\f",
+            result = "f%5Cf",
+        },
+        unicode = {
+            value = "fюf",
+            result = "f%D1%8Ef"
+        },
+        unprintable_ascii = {
+            value = string.char(15),
+            result = "%0F"
+        }
+    }
+
+    for byte = 33, 126 do
+        if byte ~= string.byte('"') and byte ~= string.byte(",") and byte ~= string.byte(";") and
+            byte ~= string.byte("\\") then
+                test_table[byte] = {
+                    value = "f" .. string.char(byte) .. "f",
+                    result = "f" .. string.char(byte) .. "f",
+                }
+        end
+    end
+
+    for case_name, case in pairs(test_table) do
+        local resp = get_object()
+        resp:setcookie({ name='name', value = case.value })
+        t.assert_equals(resp.headers['set-cookie'], {"name=" .. case.result}, case_name)
+    end
+end
+
+g.test_values_raw = function()
+    local test_table = {}
+    for byte = 0, 127 do
+        test_table[byte] = {
+            value = "f" .. string.char(byte) .. "f",
+            result = "f" .. string.char(byte) .. "f",
+        }
+    end
+
+    test_table.unicode = {
+        value = "fюf",
+        result = "fюf"
+    }
+
+    for case_name, case in pairs(test_table) do
+        local resp = get_object()
+        resp:setcookie({ name='name', value = case.value }, {raw = true})
+        t.assert_equals(resp.headers['set-cookie'], {"name=" .. case.result}, case_name)
+    end
+end
+
+g.test_path_escaping = function()
+    local test_table = {
+        semicolon = {
+            path = "f;f",
+            result = "f%3Bf",
+        },
+        unicode = {
+            path = "fюf",
+            result = "f%D1%8Ef"
+        },
+        unprintable_ascii = {
+            path = string.char(15),
+            result = "%0F"
+        }
+    }
+
+    for byte = 32, 126 do
+        if byte ~= string.byte(";") then
+            test_table[byte] = {
+                path = "f" .. string.char(byte) .. "f",
+                result = "f" .. string.char(byte) .. "f",
+            }
+        end
+    end
+
+    for case_name, case in pairs(test_table) do
+        local resp = get_object()
+        resp:setcookie({ name='name', value = 'value', path = case.path })
+        t.assert_equals(resp.headers['set-cookie'], {"name=value;" .. 'path=' .. case.result}, case_name)
+    end
+end
+
+g.test_path_raw = function()
+    local test_table = {}
+    for byte = 0, 127 do
+        test_table[byte] = {
+            path = "f" .. string.char(byte) .. "f",
+            result = "f" .. string.char(byte) .. "f",
+        }
+    end
+
+    test_table.unicode = {
+        path = "fюf",
+        result = "fюf"
+    }
+
+    for case_name, case in pairs(test_table) do
+        local resp = get_object()
+        resp:setcookie({ name='name', value = 'value', path = case.path }, {raw = true})
+        t.assert_equals(resp.headers['set-cookie'], {"name=value;" .. 'path=' .. case.result}, case_name)
+    end
+end
+
+g.test_set_header = function()
+    local test_table = {
+        name_value = {
+            cookie = {
+                name = 'name',
+                value = 'value'
+            },
+            result = {"name=value"},
+        },
+        name_value_path = {
+            cookie = {
+                name = 'name',
+                value = 'value',
+                path = 'path'
+            },
+            result = {"name=value;path=path"},
+        },
+        name_value_path_domain = {
+            cookie = {
+                name = 'name',
+                value = 'value',
+                path = 'path',
+                domain = 'domain',
+            },
+            result = {"name=value;path=path;domain=domain"},
+        },
+        name_value_path_domain_expires = {
+            cookie = {
+                name = 'name',
+                value = 'value',
+                path = 'path',
+                domain = 'domain',
+                expires = 'expires'
+            },
+            result = {"name=value;path=path;domain=domain;expires=expires"},
+        },
+    }
+
+    for case_name, case in pairs(test_table) do
+        local resp = get_object()
+        resp:setcookie(case.cookie)
+        t.assert_equals(resp.headers["set-cookie"], case.result, case_name)
+    end
+end


### PR DESCRIPTION
`resp:setcookie` implicitly escaped cookie values. Added ability to set cookie without any escaping `resp:setcookie('name', 'value', {raw = true})`.
Also added escaping for cookie path, and changed escaping algorithm according to https://tools.ietf.org/html/rfc6265.

Closes #114 