### PR TITLE
Disable option display_errors by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Disable option display_errors by default.
+
 ## [1.1.1] - 2021-10-28
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(LuaTest)
 find_package(LuaCheck)
 
 # Find Tarantool and Lua dependecies
-set(TARANTOOL_FIND_REQUIRED ON)
+set(Tarantool_FIND_REQUIRED ON)
 find_package(Tarantool)
 include_directories(${TARANTOOL_INCLUDE_DIRS})
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ function hello(self)
     return self:render({ user = user  })
 end
 
-httpd = box.httpd.new('127.0.0.1', 8080)
+httpd = httpd.new('127.0.0.1', 8080)
 httpd:route(
     { path = '/:id/view', template = 'Hello, <%= user.name %>' }, hello)
 httpd:start()

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ httpd = require('http.server').new(host, port[, { options } ])
 * `charset` - the character set for server responses of
   type `text/html`, `text/plain` and `application/json`.
 * `display_errors` - return application errors and backtraces to the client
-  (like PHP).
+  (like PHP). Disabled by default (since 1.2.0).
 * `log_requests` - log incoming requests. This parameter can receive:
     - function value, supporting C-style formatting: log_requests(fmt, ...), where fmt is a format string and ... is Lua Varargs, holding arguments to be replaced in fmt.
     - boolean value, where `true` choose default `log.info` and `false` disable request logs at all.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can:
   LuaRocks configuration details):
 
   ``` bash
-  luarocks install https://raw.githubusercontent.com/tarantool/http/master/rockspecs/http-scm-1.rockspec --local
+  luarocks --server=https://rocks.tarantool.org/ --local install http
   ```
 
 ## Usage

--- a/cmake/FindTarantool.cmake
+++ b/cmake/FindTarantool.cmake
@@ -24,7 +24,7 @@ if(TARANTOOL_INCLUDE_DIR)
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(TARANTOOL
+find_package_handle_standard_args(Tarantool
     REQUIRED_VARS TARANTOOL_INCLUDE_DIR VERSION_VAR TARANTOOL_VERSION)
 if(TARANTOOL_FOUND)
     set(TARANTOOL_INCLUDE_DIRS "${TARANTOOL_INCLUDE_DIR}"

--- a/http/server.lua
+++ b/http/server.lua
@@ -1289,7 +1289,7 @@ local exports = {
             cache_static        = true,
             log_requests        = true,
             log_errors          = true,
-            display_errors      = true,
+            display_errors      = false,
         }
 
         local self = {

--- a/http/server.lua
+++ b/http/server.lua
@@ -859,6 +859,10 @@ local function process_client(self, s, peer)
             hdrs['content-length'] = #body
         end
 
+        if hdrs['content-type'] == nil then
+            hdrs['content-type'] = 'text/plain; charset=utf-8'
+        end
+
         if hdrs.server == nil then
             hdrs.server = sprintf('Tarantool http (tarantool v%s)', _TARANTOOL)
         end

--- a/http/server.lua
+++ b/http/server.lua
@@ -1328,6 +1328,7 @@ local exports = {
     internal = {
         response_mt = response_mt,
         request_mt = request_mt,
+        extend = extend,
     }
 }
 

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -8,15 +8,18 @@ helpers.base_port = 12345
 helpers.base_host = '127.0.0.1'
 helpers.base_uri = ('http://%s:%s'):format(helpers.base_host, helpers.base_port)
 
-helpers.cfgserv = function()
+helpers.cfgserv = function(opts)
     local path = os.getenv('LUA_SOURCE_DIR') or './'
     path = fio.pathjoin(path, 'test')
 
-    local httpd = http_server.new(helpers.base_host, helpers.base_port, {
+    local opts = opts or {}
+    local opts = http_server.internal.extend({
         app_dir = path,
         log_requests = false,
         log_errors = false
-    })
+    }, opts)
+
+    local httpd = http_server.new(helpers.base_host, helpers.base_port, opts)
         :route({path = '/abc/:cde/:def', name = 'test'}, function() end)
         :route({path = '/abc'}, function() end)
         :route({path = '/ctxaction'}, 'module.controller#action')

--- a/test/integration/http_server_requests_test.lua
+++ b/test/integration/http_server_requests_test.lua
@@ -380,3 +380,13 @@ g.test_content_type_header_with_render = function()
     t.assert_equals(r.status, 200)
     t.assert_equals(r.headers['content-type'], 'text/html; charset=utf-8', 'content-type header')
 end
+
+g.test_content_type_header_without_render = function()
+    local httpd = g.httpd
+    httpd:route({
+        path = '/content_type'
+    }, function() end)
+    local r = http_client.get(helpers.base_uri .. '/content_type')
+    t.assert_equals(r.status, 200)
+    t.assert_equals(r.headers['content-type'], 'text/plain; charset=utf-8', 'content-type header')
+end

--- a/test/integration/http_server_requests_test.lua
+++ b/test/integration/http_server_requests_test.lua
@@ -365,3 +365,18 @@ g.test_request_object_methods = function()
     t.assert_equals(parsed_body.read_cached, 'hello mister',
         'non-json req:read_cached()')
 end
+
+g.test_content_type_header_with_render = function()
+    local httpd = g.httpd
+    httpd:route({
+        method = 'GET',
+        path = '/content_type',
+        file = 'helper.html.el'
+    }, function(tx)
+        return tx:render()
+    end)
+
+    local r = http_client.get(helpers.base_uri .. '/content_type')
+    t.assert_equals(r.status, 200)
+    t.assert_equals(r.headers['content-type'], 'text/html; charset=utf-8', 'content-type header')
+end

--- a/test/integration/http_server_requests_test.lua
+++ b/test/integration/http_server_requests_test.lua
@@ -7,7 +7,9 @@ local helpers = require('test.helpers')
 local g = t.group()
 
 g.before_each(function()
-    g.httpd = helpers.cfgserv()
+    g.httpd = helpers.cfgserv({
+        display_errors = true,
+    })
     g.httpd:start()
 end)
 


### PR DESCRIPTION
Fixes https://github.com/tarantool/security/issues/8
Fixes #129 
Fixes #135 
Fixes a CMake warnings for passed package names

~~**PR depends on https://github.com/tarantool/http/pull/141**~~

NOTE: Issue https://github.com/tarantool/security/issues/8 must be closed manually after merging.