### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/rockspecs/http-1.0.1-1.rockspec
+++ b/rockspecs/http-1.0.1-1.rockspec
@@ -1,7 +1,7 @@
 package = 'http'
 version = '1.0.1-1'
 source  = {
-    url = 'git://github.com/tarantool/http.git',
+    url = 'git+https://github.com/tarantool/http.git',
     tag = '1.0.1',
 }
 description = {

--- a/rockspecs/http-1.0.2-1.rockspec
+++ b/rockspecs/http-1.0.2-1.rockspec
@@ -1,7 +1,7 @@
 package = 'http'
 version = '1.0.2-1'
 source  = {
-    url = 'git://github.com/tarantool/http.git',
+    url = 'git+https://github.com/tarantool/http.git',
     tag = '1.0.2',
 }
 description = {

--- a/rockspecs/http-1.1.1-1.rockspec
+++ b/rockspecs/http-1.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = 'http'
 version = '1.1.1-1'
 source  = {
-    url = 'git://github.com/tarantool/http.git',
+    url = 'git+https://github.com/tarantool/http.git',
     tag = '1.1.1',
 }
 description = {

--- a/rockspecs/http-scm-1.rockspec
+++ b/rockspecs/http-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = 'http'
 version = 'scm-1'
 source  = {
-    url    = 'git://github.com/tarantool/http.git',
+    url    = 'git+https://github.com/tarantool/http.git',
     branch = 'master',
 }
 description = {


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Part of https://github.com/tarantool/tarantool/issues/6587