### PR TITLE
Remove Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,0 @@
-stage('Build'){
-    packpack = new org.tarantool.packpack()
-    node {
-        checkout scm
-        packpack.prepareSources()
-    }
-
-    packpack.packpackBuildMatrix('result')
-}


### PR DESCRIPTION
We don't use Jenkins as a CI for a long time, so config can be removed.