### PR TITLE
Add code coverage and coveralls support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tarantool: ['1.10', '2.5', '2.6', '2.7', '2.8']
+        tarantool: ['1.10', '2.5', '2.6', '2.7']
+        coveralls: [false]
+        include:
+          - tarantool: '2.8'
+            coveralls: true
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@master
@@ -22,7 +26,7 @@ jobs:
         id: cache-rocks
         with:
           path: .rocks/
-          key: cache-rocks-${{ matrix.tarantool }}-03
+          key: cache-rocks-${{ matrix.tarantool }}-05
 
       - run: echo $PWD/.rocks/bin >> $GITHUB_PATH
 
@@ -32,6 +36,12 @@ jobs:
         run: |
           cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build
           make -C build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run tests
-        run: make -C build luatest
+      - name: Run tests and code coverage analysis
+        run: make -C build coverage
+
+      - name: Send code coverage to coveralls.io
+        run: make -C build coveralls
+        if: ${{ matrix.coveralls }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 find_package(LuaTest)
 find_package(LuaCheck)
+find_package(LuaCov)
+find_package(LuaCovCoveralls)
+
+set(CODE_COVERAGE_REPORT "${PROJECT_SOURCE_DIR}/luacov.report.out")
+set(CODE_COVERAGE_STATS "${PROJECT_SOURCE_DIR}/luacov.stats.out")
 
 # Find Tarantool and Lua dependecies
 set(Tarantool_FIND_REQUIRED ON)
@@ -26,9 +31,34 @@ add_custom_target(luacheck
 )
 
 add_custom_target(luatest
-  COMMAND ${LUATEST} -v
+  COMMAND ${LUATEST} -v --coverage
+  BYPRODUCTS ${CODE_COVERAGE_STATS}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Run regression tests"
+)
+
+add_custom_target(coverage
+  COMMAND ${LUACOV} ${PROJECT_SOURCE_DIR} && grep -A999 '^Summary' ${CODE_COVERAGE_REPORT}
+  DEPENDS ${CODE_COVERAGE_STATS}
+  BYPRODUCTS ${CODE_COVERAGE_REPORT}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  COMMENT "Generate code coverage stats"
+)
+
+if(DEFINED ENV{GITHUB_TOKEN})
+  set(COVERALLS_COMMAND ${LUACOVCOVERALLS} --include ^http --verbose --repo-token $ENV{GITHUB_TOKEN})
+else()
+  set(COVERALLS_COMMAND ${CMAKE_COMMAND} -E echo "Skipped uploading to coveralls.io: no token.")
+endif()
+
+add_custom_target(coveralls
+  # Replace absolute paths with relative ones.
+  # In command line: sed -i -e 's@'"$(realpath .)"'/@@'.
+  COMMAND sed -i -e "\"s@\"'${PROJECT_SOURCE_DIR}'\"/@@\"" ${CODE_COVERAGE_STATS}
+  COMMAND ${COVERALLS_COMMAND}
+  DEPENDS ${CODE_COVERAGE_STATS}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  COMMENT "Send code coverage data to the coveralls.io service"
 )
 
 set (LUA_PATH "LUA_PATH=${PROJECT_SOURCE_DIR}/?.lua\\;${PROJECT_SOURCE_DIR}/?/init.lua\\;\\;")

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ align="right">
 
 [![Static analysis](https://github.com/tarantool/http/actions/workflows/check_on_push.yaml/badge.svg)](https://github.com/tarantool/http/actions/workflows/check_on_push.yaml)
 [![Test](https://github.com/tarantool/http/actions/workflows/test.yml/badge.svg)](https://github.com/tarantool/http/actions/workflows/test.yml)
+[![Coverage Status](https://coveralls.io/repos/github/tarantool/http/badge.svg?branch=master)](https://coveralls.io/github/tarantool/http?branch=master)
 
 > **Note:** In Tarantool 1.7.5+, a full-featured HTTP client is available aboard.
 > For Tarantool 1.6.5+, both HTTP server and client are available

--- a/cmake/FindLuaCov.cmake
+++ b/cmake/FindLuaCov.cmake
@@ -1,0 +1,12 @@
+find_program(LUACOV luacov
+    HINTS .rocks/
+    PATH_SUFFIXES bin
+    DOC "Lua test coverage analysis"
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LuaCov
+    REQUIRED_VARS LUACOV
+)
+
+mark_as_advanced(LUACOV)

--- a/cmake/FindLuaCovCoveralls.cmake
+++ b/cmake/FindLuaCovCoveralls.cmake
@@ -1,0 +1,12 @@
+find_program(LUACOVCOVERALLS luacov-coveralls
+    HINTS .rocks/
+    PATH_SUFFIXES bin
+    DOC "LuaCov reporter for coveralls.io service"
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LuaCovCoveralls
+    REQUIRED_VARS LUACOVCOVERALLS
+)
+
+mark_as_advanced(LUACOVCOVERALLS)

--- a/deps.sh
+++ b/deps.sh
@@ -6,5 +6,11 @@ set -e
 
 # Test dependencies:
 tarantoolctl rocks install luatest 0.5.5
+tarantoolctl rocks install luacheck 0.25.0
+tarantoolctl rocks install luacov 0.13.0
+
+# cluacov, luacov-coveralls and dependencies
+tarantoolctl rocks install luacov-coveralls 0.2.3-1 --server=https://luarocks.org
+tarantoolctl rocks install cluacov 0.1.2-1 --server=https://luarocks.org
 
 tarantoolctl rocks make


### PR DESCRIPTION
Patch adds a support of code coverage for Lua source code and Coveralls
support, see [1].

1. https://coveralls.io/github/tarantool/http