### PR TITLE
Added the ability to use a non-standard socket (for example, with support   for SSL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Allow to use a non-standard socket (for example, `sslsocket` with TLS
+  support).
+
 ## [1.2.0] - 2021-11-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ http v2 revert and decisions regarding each reverted commit see
   * [handler(httpd, req)](#handlerhttpd-req)
   * [before\_dispatch(httpd, req)](#before_dispatchhttpd-req)
   * [after\_dispatch(cx, resp)](#after_dispatchcx-resp)
+* [Using a special socket](#using-a-special-socket)
 * [See also](#see-also)
 
 ## Prerequisites
@@ -448,6 +449,40 @@ and the response produced by the handler.
 
 This hook can be used to modify the response.
 The return value of the hook is ignored.
+
+## Using a special socket
+
+To use a special socket, override the `tcp_server_f` field of the HTTP server
+object with your own function. The function should return an object similar to
+one returned by [socket.tcp_server][socket_ref]. It should call `opts.handler`
+when a connection occurs and provide `read`, `write` and `close` methods.
+
+Example:
+
+```lua
+local httpd = require('http.server')
+local server = httpd.new(settings.host, settings.port)
+
+-- Use sslsocket.
+local sslsocket = require('sslsocket')
+server.tcp_server_f = sslsocket.tcp_server
+
+-- Or use your own handler.
+server.tcp_server_f = function(host, port, opts)
+    assert(type(opts) == 'table')
+    local name = opts.name
+    local accept_handler = opts.handler
+    local http_server = opts.http_server
+
+    <...>
+    return <..tcp server object..>
+end
+
+server:route(<your settings>)
+server:start()
+```
+
+[socket_ref]: https://www.tarantool.io/en/doc/latest/reference/reference_lua/socket/#socket-tcp-server
 
 ## See also
 

--- a/http/server.lua
+++ b/http/server.lua
@@ -1256,11 +1256,14 @@ local function httpd_start(self)
         error("httpd: usage: httpd:start()")
     end
 
-    local server = socket.tcp_server(self.host, self.port,
-                     { name = 'http',
-                       handler = function(...)
-                           process_client(self, ...)
-                     end})
+    local server = self.tcp_server_f(self.host, self.port, {
+        name = 'http',
+        handler = function(...)
+            process_client(self, ...)
+        end,
+        http_server = self,
+    })
+
     if server == nil then
         error(sprintf("Can't create tcp_server: %s", errno.strerror()))
     end
@@ -1317,6 +1320,9 @@ local exports = {
             helper  = set_helper,
             hook    = set_hook,
             url_for = url_for_httpd,
+
+            -- Exposed to make it replaceable by a user.
+            tcp_server_f = socket.tcp_server,
 
             -- caches
             cache   = {

--- a/test/unit/http_custom_socket_test.lua
+++ b/test/unit/http_custom_socket_test.lua
@@ -1,0 +1,50 @@
+local t = require('luatest')
+local http_server = require('http.server')
+
+local g = t.group()
+
+g.test_custom_socket = function()
+    local is_listening = false
+
+    local function tcp_server(host, port, opts)
+        assert(type(opts) == 'table')
+        local name = opts.name
+        local accept_handler = opts.handler
+        local http_server = opts.http_server
+
+        -- Verify arguments.
+        t.assert_equals(host, 'host', 'check host')
+        t.assert_equals(port, 123, 'check port')
+
+        -- Verify options.
+        t.assert_equals(name, 'http', 'check server name')
+        t.assert_type(accept_handler, 'function', 'check accept handler')
+        t.assert_type(http_server.routes, 'table',
+            'http server object is accessible')
+
+        is_listening = true
+        return {
+            close = function(self)
+                is_listening = false
+            end
+        }
+    end
+
+    local myhttp = http_server.new('host', 123)
+    myhttp.tcp_server_f = tcp_server
+    myhttp:route({path = '/abc'}, function(_) end)
+    myhttp:start()
+    t.assert_equals(is_listening, true, 'custom socket is actually used')
+
+    -- The key reason why the field is called `tcp_server_f` is
+    -- that the HTTP server sets `myhttp.tcp_server` to the TCP
+    -- server object. The name clash is harmless for the module,
+    -- but may confuse a user, so the `tcp_server_f` was chosen
+    -- instead of just `tcp_server`. The `tcp_server_f` field is
+    -- guaranteed to remains the same after `myhttp:start()`.
+    t.assert_equals(myhttp.tcp_server_f, tcp_server,
+        'tcp_server_f field was not changed after :start()')
+
+    myhttp:stop()
+    t.assert_equals(is_listening, false, 'custom socket was closed')
+end


### PR DESCRIPTION
In continuation [pull 158](https://github.com/tarantool/http/pull/158).
Please review and accept the changes. Admonitions have been taken into account.
Summary:
1. The `tcp_server` socket method call has been separated into a separate http `listen` method so that `listen` can be overridden and use a different socket.
2. `requirement('socket')` moved inside procedure as it is only referenced by the default implementation. If the procedure is overridden, then the call is not needed. Just too much.
On the other hand, placement on top makes sense for understanding what modules are needed or potentially needed. I don't know which is better. Ready to redo, of course.
3. Fixed syntax
4. Add info to README
5. Add unit test (for regress testing)
6. Add info to CHANGELOG