### PR TITLE
Do not treat ./ as invalid uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add versioning support.
 
+### Fixed
+
+- Allow dot in path segment.
+
 ## [1.4.0] - 2022-12-30
 
 ### Added

--- a/http/server.lua
+++ b/http/server.lua
@@ -746,10 +746,17 @@ local function parse_request(req)
     end
     p.path_raw = p.path
     p.path = uri_unescape(p.path)
-    if p.path:sub(1, 1) ~= "/" or p.path:find("./", nil, true) ~= nil then
+    if p.path:sub(1, 1) ~= "/" then
         p.error = "invalid uri"
         return p
     end
+    for _, path_segment in ipairs(p.path:split('/')) do
+        if path_segment == "." or path_segment == ".." then
+            p.error = "invalid uri"
+            return p
+        end
+    end
+
     return p
 end
 

--- a/test/integration/http_server_requests_test.lua
+++ b/test/integration/http_server_requests_test.lua
@@ -417,3 +417,12 @@ g.test_content_type_header_without_render = function()
     t.assert_equals(r.status, 200)
     t.assert_equals(r.headers['content-type'], 'text/plain; charset=utf-8', 'content-type header')
 end
+
+g.test_get_dot_slash = function()
+    local httpd = g.httpd
+    httpd:route({
+        path = '/*dot_slash'
+    }, function() end)
+    local r = http_client.get(helpers.base_uri .. '/dot_slash.')
+    t.assert_equals(r.status, 200)
+end


### PR DESCRIPTION
Do not treat ./ as invalid uri.
Fixes https://github.com/tarantool/http/issues/171.

```
$ .rocks/bin/luatest -v test/
...
=========================================================
Ran 56 tests in 0.648 seconds, 56 succeeded, 0 failed
```