### PR TITLE
Add the path_raw field to a request object

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ end
 
 * `req.method` - HTTP request type (`GET`, `POST` etc).
 * `req.path` - request path.
+* `req.path_raw` - request path without decoding.
 * `req.query` - request arguments.
 * `req.proto` - HTTP version (for example, `{ 1, 1 }` is `HTTP/1.1`).
 * `req.headers` - normalized request headers. A normalized header

--- a/http/server.lua
+++ b/http/server.lua
@@ -744,6 +744,7 @@ local function parse_request(req)
     if p.error then
         return p
     end
+    p.path_raw = p.path
     p.path = uri_unescape(p.path)
     if p.path:sub(1, 1) ~= "/" or p.path:find("./", nil, true) ~= nil then
         p.error = "invalid uri"


### PR DESCRIPTION
Add a ability to get the request path without decoding

Maybe it closes #56, but I'm not sure :)