### PR TITLE
bug: fixed missing entry about version file

### DIFF
--- a/http-scm-1.rockspec
+++ b/http-scm-1.rockspec
@@ -28,6 +28,7 @@ build = {
             }
         },
         ['http.server'] = 'http/server.lua',
+        ['http.version'] = 'http/version.lua',
         ['http.mime_types'] = 'http/mime_types.lua',
         ['http.codes'] = 'http/codes.lua',
     }


### PR DESCRIPTION
Added a missing version file entry to the `build.modules` list in the rockspec file. Now, when installing the module via rockspec, the http/version.lua file is copied to the installation location.

Closes #185