### PR TITLE
Remove redundant URI path segment check in parse_request

### DIFF
--- a/http/server.lua
+++ b/http/server.lua
@@ -754,12 +754,6 @@ local function parse_request(req)
         p.error = "invalid uri"
         return p
     end
-    for _, path_segment in ipairs(p.path:split('/')) do
-        if path_segment == "." or path_segment == ".." then
-            p.error = "invalid uri"
-            return p
-        end
-    end
 
     return p
 end


### PR DESCRIPTION
This commit proposes the removal of a redundant URI path segment check within the `parse_request` function. 

Currently, the code contains a loop that iterates over each path segment in the parsed URI, checking for the presence of `.` or `..` segments. However, this check is unnecessary since HTTP requests with `/./` or `/../` in the URI are automatically corrected by the http server, converting them into `//` which is the expected behavior.

The primary reason for removing this check is to address an issue detailed in the GitHub pull request https://github.com/tarantool/http/pull/173. In cases where Tarantool decodes a request like `.%2F.html.%2F` to `./.html./`, the current code implementation throws an `invalid uri` error. However, this behavior is not desired. Instead, it is expected to return the URI as is.