### PR TITLE
Replace tarantoolctl with tt

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ You can:
   make install
   ```
 
-* install the `http` module using `tarantoolctl`:
+* install the `http` module using [tt](https://github.com/tarantool/tt):
 
   ``` bash
-  tarantoolctl rocks install http
+  tt rocks install http
   ```
 
 * install the `http` module using LuaRocks


### PR DESCRIPTION
As a part of https://github.com/tarantool/doc/issues/3730, we need to start recommending our users to utilize tt instead of the tarantoolctl utility.