### PR TITLE
roles: introduce role for http servers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,17 +10,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tarantool: ['1.10', '2.5', '2.6', '2.7', '2.8']
+        tarantool: ['1.10', '2.10', '2.11', '3.1', '3.2']
         coveralls: [false]
         include:
-          - tarantool: '2.10'
+          - tarantool: '2.11'
             coveralls: true
     runs-on: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@master
-      - uses: tarantool/setup-tarantool@v1
+      - uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: ${{ matrix.tarantool }}
+
+      - name: Prepare the repo
+        run: curl -L https://tarantool.io/release/2/installer.sh | bash
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
+      - name: Install tt cli
+        run: sudo apt install -y tt=2.4.0
+        env:
+          DEBIAN_FRONTEND: noninteractive
 
       - name: Cache rocks
         uses: actions/cache@v2
@@ -40,8 +50,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run tests and code coverage analysis
-        run: make -C build coverage
+      - name: Run tests without code coverage analysis
+        run: make -C build luatest
+        if: matrix.coveralls != true
 
       - name: Send code coverage to coveralls.io
         run: make -C build coveralls

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -9,6 +9,8 @@ ignore = {
     "143/string",
     -- Accessing an undefined field of a global variable <table>.
     "143/table",
+    -- Accessing an undefined field of a global variable <package>.
+    "143/package",
     -- Unused argument <self>.
     "212/self",
     -- Redefining a local variable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `roles.httpd` role to configure one or more HTTP servers (#196)
+- `httpd:delete(name)` method to delete named routes (#197)
 
 ## [1.5.0] - 2023-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
+
 - Fixed request crash with empty body and unexpected header Content-Type (#189)
+
+### Added
+
+- `roles.httpd` role to configure one or more HTTP servers (#196)
 
 ## [1.5.0] - 2023-03-29
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Wextra")
 string(RANDOM ALPHABET 0123456789 seed)
 
 add_subdirectory(http)
+add_subdirectory(roles)
 
 add_custom_target(luacheck
   COMMAND ${LUACHECK} ${PROJECT_SOURCE_DIR}
@@ -32,11 +33,17 @@ add_custom_target(luacheck
   COMMENT "Run luacheck"
 )
 
-add_custom_target(luatest
+add_custom_target(luatest-coverage
   COMMAND ${LUATEST} -v --coverage --shuffle all:${seed}
   BYPRODUCTS ${CODE_COVERAGE_STATS}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  COMMENT "Run regression tests"
+  COMMENT "Run regression tests with coverage"
+)
+
+add_custom_target(luatest
+  COMMAND ${LUATEST} -v --shuffle all:${seed}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMENT "Run regression tests without coverage"
 )
 
 add_custom_target(coverage
@@ -65,4 +72,4 @@ add_custom_target(coveralls
 
 set (LUA_PATH "LUA_PATH=${PROJECT_SOURCE_DIR}/?.lua\\;${PROJECT_SOURCE_DIR}/?/init.lua\\;\\;")
 set (LUA_SOURCE_DIR "LUA_SOURCE_DIR=${PROJECT_SOURCE_DIR}")
-set_target_properties(luatest PROPERTIES ENVIRONMENT "${LUA_PATH};${LUA_SOURCE_DIR}")
+set_target_properties(luatest-coverage PROPERTIES ENVIRONMENT "${LUA_PATH};${LUA_SOURCE_DIR}")

--- a/README.md
+++ b/README.md
@@ -184,6 +184,13 @@ httpd:route({ path = '/objects', method = 'GET' }, handle3)
 ...
 ```
 
+To delete a named route, use `delete()` method of the `httpd` object:
+
+```lua
+httpd:route({ path = '/path/to', name = 'route' }, 'controller#action')
+httpd:delete('route')
+```
+
 The first argument for `route()` is a Lua table with one or more keys:
 
 * `file` - a template file name (can be relative to.

--- a/deps.sh
+++ b/deps.sh
@@ -5,13 +5,14 @@
 set -e
 
 # Test dependencies:
-tarantoolctl rocks install luatest 0.5.7
-tarantoolctl rocks install luacheck 0.25.0
-tarantoolctl rocks install luacov 0.13.0
-tarantoolctl rocks install luafilesystem 1.7.0-2
+# Could be replaced with luatest >= 1.1.0 after a release.
+tt rocks install luatest
+tt rocks install luacheck 0.25.0
+tt rocks install luacov 0.13.0
+tt rocks install luafilesystem 1.7.0-2
 
 # cluacov, luacov-coveralls and dependencies
-tarantoolctl rocks install luacov-coveralls 0.2.3-1 --server=https://luarocks.org
-tarantoolctl rocks install cluacov 0.1.2-1 --server=https://luarocks.org
+tt rocks install luacov-coveralls 0.2.3-1 --server=https://luarocks.org
+tt rocks install cluacov 0.1.2-1 --server=https://luarocks.org
 
-tarantoolctl rocks make
+tt rocks make

--- a/http-scm-1.rockspec
+++ b/http-scm-1.rockspec
@@ -31,6 +31,7 @@ build = {
         ['http.version'] = 'http/version.lua',
         ['http.mime_types'] = 'http/mime_types.lua',
         ['http.codes'] = 'http/codes.lua',
+        ['roles.httpd'] = 'roles/httpd.lua',
     }
 }
 

--- a/http/server.lua
+++ b/http/server.lua
@@ -1260,6 +1260,23 @@ local function add_route(self, opts, sub)
     return self
 end
 
+local function delete_route(self, name)
+    local route = self.iroutes[name]
+    if route == nil then
+        return
+    end
+
+    self.iroutes[name] = nil
+    table.remove(self.routes, route)
+
+    -- Update iroutes numeration.
+    for n, r in ipairs(self.routes) do
+        if r.name then
+            self.iroutes[r.name] = n
+        end
+    end
+end
+
 local function url_for_httpd(httpd, name, args, query)
 
     local idx = httpd.iroutes[ name ]
@@ -1357,6 +1374,7 @@ local exports = {
 
             -- methods
             route   = add_route,
+            delete  = delete_route,
             match   = match_route,
             helper  = set_helper,
             hook    = set_hook,

--- a/roles/CMakeLists.txt
+++ b/roles/CMakeLists.txt
@@ -1,0 +1,2 @@
+# Install.
+install(FILES httpd.lua DESTINATION ${TARANTOOL_INSTALL_LUADIR}/roles)

--- a/roles/httpd.lua
+++ b/roles/httpd.lua
@@ -1,0 +1,133 @@
+local checks = require('checks')
+local urilib = require('uri')
+local http_server = require('http.server')
+
+local M = {
+    DEFAULT_SERVER_NAME = 'default',
+}
+local servers = {}
+
+local function parse_listen(listen)
+    if listen == nil then
+        return nil, nil, "must exist"
+    end
+    if type(listen) ~= "string" and type(listen) ~= "number" then
+        return nil, nil, "must be a string or a number, got " .. type(listen)
+    end
+
+    local host
+    local port
+    if type(listen) == "string" then
+        local uri, err = urilib.parse(listen)
+        if err ~= nil then
+            return nil, nil, "failed to parse URI: " .. err
+        end
+
+        if uri.scheme ~= nil then
+            if uri.scheme == "unix" then
+                uri.unix = uri.path
+            else
+                return nil, nil, "URI scheme is not supported"
+            end
+        end
+
+        if uri.login ~= nil or uri.password then
+            return nil, nil, "URI login and password are not supported"
+        end
+
+        if uri.query ~= nil then
+            return nil, nil, "URI query component is not supported"
+        end
+
+        if uri.unix ~= nil then
+            host = "unix/"
+            port = uri.unix
+        else
+            if uri.service == nil then
+                return nil, nil, "URI must contain a port"
+            end
+
+            port = tonumber(uri.service)
+            if port == nil then
+                return nil, nil, "URI port must be a number"
+            end
+            if uri.host ~= nil then
+                host = uri.host
+            elseif uri.ipv4 ~= nil then
+                host = uri.ipv4
+            elseif uri.ipv6 ~= nil then
+                host = uri.ipv6
+            else
+                host = "0.0.0.0"
+            end
+        end
+    elseif type(listen) == "number" then
+        host = "0.0.0.0"
+        port = listen
+    end
+
+    if type(port) == "number" and (port < 1 or port > 65535) then
+        return nil, nil, "port must be in the range [1, 65535]"
+    end
+    return host, port, nil
+end
+
+local function apply_http(name, node)
+    local host, port, err = parse_listen(node.listen)
+    if err ~= nil then
+        error("failed to parse URI: " .. err)
+    end
+
+    if servers[name] == nil then
+        local httpd = http_server.new(host, port)
+        httpd:start()
+        servers[name] = {
+            httpd = httpd,
+            routes = {},
+        }
+    end
+end
+
+M.validate = function(conf)
+    if conf ~= nil and type(conf) ~= "table" then
+        error("configuration must be a table, got " .. type(conf))
+    end
+    conf = conf or {}
+
+    for name, node in pairs(conf) do
+        if type(name) ~= 'string' then
+            error("name of the server must be a string")
+        end
+
+        local _, _, err = parse_listen(node.listen)
+        if err ~= nil then
+            error("failed to parse http 'listen' param: " .. err)
+        end
+    end
+end
+
+M.apply = function(conf)
+    -- This should be called on the role's lifecycle, but it's better to give
+    -- a meaningful error if something goes wrong.
+    M.validate(conf)
+
+    for name, node in pairs(conf or {}) do
+        apply_http(name, node)
+    end
+end
+
+M.stop = function()
+    for _, server in pairs(servers) do
+        server.httpd:stop()
+    end
+    servers = {}
+end
+
+M.get_server = function(name)
+    checks('?string')
+
+    name = name or M.DEFAULT_SERVER_NAME
+    return (servers[name] or {}).httpd
+end
+
+return M

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -4,6 +4,9 @@ local socket = require('socket')
 
 local helpers = table.copy(require('luatest').helpers)
 
+local luatest = require('luatest')
+local luatest_utils = require('luatest.utils')
+
 helpers.base_port = 12345
 helpers.base_host = '127.0.0.1'
 helpers.base_uri = ('http://%s:%s'):format(helpers.base_host, helpers.base_port)
@@ -99,6 +102,27 @@ helpers.teardown = function(httpd)
         end
         assert(s == nil, 'http server is stopped')
     end)
+end
+
+helpers.is_tarantool3 = function()
+    local tarantool_version = luatest_utils.get_tarantool_version()
+    return luatest_utils.version_ge(tarantool_version, luatest_utils.version(3, 0, 0))
+end
+
+helpers.skip_if_not_tarantool3 = function()
+    luatest.skip_if(not helpers.is_tarantool3(), 'Only Tarantool 3 is supported')
+end
+
+helpers.update_lua_env_variables = function(server)
+    local ROOT = fio.dirname(fio.dirname(fio.abspath(package.search('http.server'))))
+
+    server.env.LUA_PATH = (server.env.LUA_PATH or '') ..
+        ROOT .. '/?.lua;' .. ROOT .. '/?/?.lua;' ..
+        ROOT .. '/.rocks/share/tarantool/?.lua;' ..
+        ROOT .. '/.rocks/share/tarantool/?/init.lua;'
+    server.env.LUA_CPATH = (server.env.LUA_CPATH or '') ..
+        ROOT .. '/.rocks/lib/tarantool/?.so;' ..
+        ROOT .. '/.rocks/lib/tarantool/?/?.so;'
 end
 
 return helpers

--- a/test/integration/http_server_delete_test.lua
+++ b/test/integration/http_server_delete_test.lua
@@ -1,0 +1,37 @@
+local t = require('luatest')
+local http_client = require('http.client')
+
+local helpers = require('test.helpers')
+
+local g = t.group()
+
+g.before_each(function()
+    g.httpd = helpers.cfgserv({
+        display_errors = true,
+    })
+    g.httpd:start()
+end)
+
+g.after_each(function()
+    helpers.teardown(g.httpd)
+end)
+
+g.test_delete = function()
+    local httpd = g.httpd
+    httpd:route({
+        path = '/content_type',
+        name = 'content_type',
+    }, function()
+        return {
+            status = 200,
+        }
+    end)
+
+    local r = http_client.get(helpers.base_uri .. '/content_type')
+    t.assert_equals(r.status, 200)
+
+    httpd:delete('content_type')
+
+    r = http_client.get(helpers.base_uri .. '/content_type')
+    t.assert_equals(r.status, 404)
+end

--- a/test/integration/httpd_role_test.lua
+++ b/test/integration/httpd_role_test.lua
@@ -1,0 +1,83 @@
+local t = require('luatest')
+local treegen = require('luatest.treegen')
+local server = require('luatest.server')
+local fun = require('fun')
+local yaml = require('yaml')
+
+local helpers = require('test.helpers')
+
+local g = t.group()
+
+local config = {
+    credentials = {
+        users = {
+            guest = {
+                roles = {'super'},
+            },
+        },
+    },
+    iproto = {
+        listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
+    },
+    groups = {
+        ['group-001'] = {
+            replicasets = {
+                ['replicaset-001'] = {
+                    roles = {
+                        'roles.httpd',
+                        'test.mocks.mock_role',
+                    },
+                    roles_cfg = {
+                        ['roles.httpd'] = {
+                            default = {
+                                listen = 13000,
+                            },
+                            additional = {
+                                listen = 13001,
+                            }
+                        },
+                        ['test.mocks.mock_role'] = {
+                            {
+                                id = 1,
+                            },
+                            {
+                                id = 2,
+                                name = 'additional',
+                            },
+                        },
+                    },
+                    instances = {
+                        ['instance-001'] = {},
+                    },
+                },
+            },
+        },
+    },
+}
+
+g.before_each(function()
+    helpers.skip_if_not_tarantool3()
+
+    local dir = treegen.prepare_directory({}, {})
+
+    local config_file = treegen.write_file(dir, 'config.yaml',
+        yaml.encode(config))
+    local opts = {config_file = config_file, chdir = dir}
+    g.server = server:new(fun.chain(opts, {alias = 'instance-001'}):tomap())
+    helpers.update_lua_env_variables(g.server)
+
+    g.server:start()
+end)
+
+g.after_each(function()
+    g.server:stop()
+end)
+
+g.test_httpd_role_usage = function()
+    t.assert_equals(g.server:eval(
+        'return require("test.mocks.mock_role").get_server_port(1)'
+    ), 13000)
+    t.assert_equals(g.server:eval(
+        'return require("test.mocks.mock_role").get_server_port(2)'
+    ), 13001)
+end

--- a/test/mocks/mock_role.lua
+++ b/test/mocks/mock_role.lua
@@ -1,0 +1,19 @@
+local M = {dependencies = { 'roles.httpd' }}
+
+local servers = {}
+
+M.validate = function() end
+
+M.apply = function(conf)
+    for _, server in pairs(conf) do
+        servers[server.id] = require('roles.httpd').get_server(server.name)
+    end
+end
+
+M.stop = function() end
+
+M.get_server_port = function(id)
+    return servers[id].port
+end
+
+return M

--- a/test/unit/httpd_role_test.lua
+++ b/test/unit/httpd_role_test.lua
@@ -1,0 +1,183 @@
+local t = require('luatest')
+local g = t.group()
+
+local httpd_role = require('roles.httpd')
+
+g.after_each(function()
+    httpd_role.stop()
+end)
+
+local validation_cases = {
+    ["not_table"] = {
+        cfg = 42,
+        err = "configuration must be a table, got number",
+    },
+    ["name_not_string"] = {
+        cfg = {
+            [42] = {
+                listen = 8081,
+            },
+        },
+        err = "name of the server must be a string",
+    },
+    ["listen_not_exist"] = {
+        cfg = {
+            server = {
+                listen = nil,
+            },
+        },
+        err = "failed to parse http 'listen' param: must exist",
+    },
+    ["listen_not_string_and_not_number"] = {
+        cfg = {
+            server = {
+                listen = {},
+            },
+        },
+        err = "failed to parse http 'listen' param: must be a string or a number, got table",
+    },
+    ["listen_port_too_small"] = {
+        cfg = {
+            server = {
+                listen = 0,
+            },
+        },
+        err = "failed to parse http 'listen' param: port must be in the range [1, 65535]",
+    },
+    ["listen_port_in_range"] = {
+        cfg = {
+            server = {
+                listen = 8081,
+            },
+        },
+    },
+    ["listen_port_too_big"] = {
+        cfg = {
+            server = {
+                listen = 65536,
+            },
+        },
+        err = "failed to parse http 'listen' param: port must be in the range [1, 65535]",
+    },
+    ["listen_uri_no_port"] = {
+        cfg = {
+            server = {
+                listen = "localhost",
+            },
+        },
+        err = "failed to parse http 'listen' param: URI must contain a port",
+    },
+    ["listen_uri_port_too_small"] = {
+        cfg = {
+            server = {
+                listen = "localhost:0",
+            },
+        },
+        err = "failed to parse http 'listen' param: port must be in the range [1, 65535]",
+    },
+    ["listen_uri_with_port_in_range"] = {
+        cfg = {
+            server = {
+                listen = "localhost:8081",
+            },
+        },
+    },
+    ["listen_uri_port_too_big"] = {
+        cfg = {
+            server = {
+                listen = "localhost:65536",
+            },
+        },
+        err = "failed to parse http 'listen' param: port must be in the range [1, 65535]",
+    },
+    ["listen_uri_port_not_number"] = {
+        cfg = {
+            server = {
+                listen = "localhost:foo",
+            },
+        },
+        err = "failed to parse http 'listen' param: URI port must be a number",
+    },
+    ["listen_uri_non_unix_scheme"] = {
+        cfg = {
+            server = {
+                listen = "http://localhost:123",
+            },
+        },
+        err = "failed to parse http 'listen' param: URI scheme is not supported",
+    },
+    ["listen_uri_login_password"] = {
+        cfg = {
+            server = {
+                listen = "login:password@localhost:123",
+            },
+        },
+        err = "failed to parse http 'listen' param: URI login and password are not supported",
+    },
+    ["listen_uri_query"] = {
+        cfg = {
+            server = {
+                listen = "localhost:123/?foo=bar",
+            },
+        },
+        err = "failed to parse http 'listen' param: URI query component is not supported",
+    },
+}
+
+for name, case in pairs(validation_cases) do
+    local test_name = ('test_validate_http_%s%s'):format(
+        (case.err ~= nil) and 'fails_on_' or 'success_for_',
+        name
+    )
+
+    g[test_name] = function()
+        local ok, res = pcall(httpd_role.validate, case.cfg)
+
+        if case.err ~= nil then
+            t.assert_not(ok)
+            t.assert_str_contains(res, case.err)
+        else
+            t.assert(ok)
+            t.assert_is(res, nil)
+        end
+    end
+end
+
+g['test_get_default_without_apply'] = function()
+    local result = httpd_role.get_server()
+    t.assert_is(result, nil)
+end
+
+g['test_get_default_no_default'] = function()
+    local cfg = {
+        not_a_default = {
+            listen = 13000,
+        },
+    }
+
+    httpd_role.apply(cfg)
+
+    local result = httpd_role.get_server()
+    t.assert_is(result, nil)
+end
+
+g['test_get_default'] = function()
+    local cfg = {
+        [httpd_role.DEFAULT_SERVER_NAME] = {
+            listen = 13001,
+        },
+    }
+
+    httpd_role.apply(cfg)
+
+    local result = httpd_role.get_server()
+    t.assert_not_equals(result, nil)
+    t.assert_is(result.port, 13001)
+end
+
+g['test_get_server_bad_type'] = function()
+    local ok, res = pcall(httpd_role.get_server, {})
+
+    t.assert_not(ok)
+    t.assert_str_contains(res, '?string expected, got table')
+end


### PR DESCRIPTION
This patch adds `roles.http_server`. This role allows to configurate one or more HTTP servers. Those servers could be reused by several other roles.

Servers could be accessed by their names (from the config).

`get_server(name)` method returns a server by its name. If `nil` is passed, default server is returned. The server is  default, if it has `DEFAULT_SERVER_NAME` (`"default"`) as a name.

This patch also adds a `httpd:delete(name)` method to delete named routes.

Closes #196