### PR TITLE
Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
 ### Fixed
 
-- Fixed request crash with empty body and unexpected header Content-Type (#189)
+## [1.6.0] - 2024-09-13
+
+The release introduces a role for Tarantool 3.
+
+### Fixed
+
+- Fixed request crash with empty body and unexpected header
+  Content-Type (#189).
 
 ### Added
 
-- `roles.httpd` role to configure one or more HTTP servers (#196)
-- `httpd:delete(name)` method to delete named routes (#197)
+- `roles.httpd` role to configure one or more HTTP servers (#196).
+- `httpd:delete(name)` method to delete named routes (#197).
 
 ## [1.5.0] - 2023-03-29
 

--- a/http/version.lua
+++ b/http/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.5.0'
+return '1.6.0'


### PR DESCRIPTION
The release introduces a role for Tarantool 3.

### Fixed

- Fixed request crash with empty body and unexpected header Content-Type (#189).

### Added

- `roles.httpd` role to configure one or more HTTP servers (#196).
- `httpd:delete(name)` method to delete named routes (#197).