### PR TITLE
rockspec: add sslsocket

### DIFF
--- a/http-scm-1.rockspec
+++ b/http-scm-1.rockspec
@@ -28,6 +28,7 @@ build = {
             }
         },
         ['http.server'] = 'http/server.lua',
+        ['http.sslsocket'] = 'http/sslsocket.lua',
         ['http.version'] = 'http/version.lua',
         ['http.mime_types'] = 'http/mime_types.lua',
         ['http.codes'] = 'http/codes.lua',


### PR DESCRIPTION
Since TLS support was merged, it has been forgotten to add new `sslsocket.lua` file into rockspec. It's impossible to start installed http module without this file.

After the patch `sslsocket.lua` was added into rockspec file.