### PR TITLE
ci: update Ubuntu runners

### DIFF
--- a/.github/workflows/check_on_push.yaml
+++ b/.github/workflows/check_on_push.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Tarantool
       uses: tarantool/setup-tarantool@v3
       with:
-        tarantool-version: '2.8'
+        tarantool-version: '2.11'
 
     - name: Setup luacheck
       run: tarantoolctl rocks install luacheck 0.25.0

--- a/.github/workflows/check_on_push.yaml
+++ b/.github/workflows/check_on_push.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Setup Tarantool
-      uses: tarantool/setup-tarantool@v1
+      uses: tarantool/setup-tarantool@v3
       with:
         tarantool-version: '2.8'
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   # Run not only on tags, otherwise dependent job will skip.
   version-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check module version
         # We need this step to run only on push with tag.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ jobs:
   version-check:
     # We need this job to run only on push with tag.
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check module version
         uses: tarantool/actions/check-module-version@master

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: tarantool/rocks.tarantool.org/github-action@master
         with:
           auth: ${{ secrets.ROCKS_AUTH }}
@@ -50,8 +50,8 @@ jobs:
       # LuaJIT's FFI and tarantool specific features are okay.
       #
       # [1]: https://github.com/luarocks/luarocks/wiki/Types-of-rocks
-      - uses: actions/checkout@v2
-      - uses: tarantool/setup-tarantool@v1
+      - uses: actions/checkout@v3
+      - uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: '2.5'
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: tarantool/setup-tarantool@v3
         with:
-          tarantool-version: '2.5'
+          tarantool-version: '2.11'
 
       # Make a release
       - run: echo TAG=${GITHUB_REF##*/} >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - tarantool: '2.11'
             coveralls: true
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@master
       - uses: tarantool/setup-tarantool@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         run: tt install tarantool ${{ matrix.tarantool }} --dynamic
 
       - name: Cache rocks
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-rocks
         with:
           path: .rocks/


### PR DESCRIPTION
Ubuntu version 20.04 will soon be fully unsupported, so this patch updates it to 22.04.
Also old actions versions are updated and deprecated Tarantool versions are also changed.

https://github.com/actions/runner-images/issues/11101

Closes TNTP-1058