### PR TITLE
roles: add log_requests option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `log_requests` option into `roles.httpd`.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -536,10 +536,15 @@ roles_cfg:
       listen: 8081
     additional:
       listen: '127.0.0.1:8082'
+      log_requests: 'verbose'
 ```
 
 Server address should be provided either as a URI or as a single port
 (in this case, `0.0.0.0` address is used).
+
+You can configure HTTP request logging level using `log_requests` parameter (e.g. "verbose").
+Supported values are "debug", "verbose", "info", "warn" and "error".
+By default, requests are logged at "info" level.
 
 User can access every working HTTP server from the configuration by name,
 using `require('roles.httpd').get_server(name)` method.

--- a/roles/httpd.lua
+++ b/roles/httpd.lua
@@ -1,5 +1,6 @@
 local checks = require('checks')
 local urilib = require('uri')
+local log = require('log')
 local http_server = require('http.server')
 
 local M = {
@@ -75,7 +76,28 @@ end
 -- parse_params returns table with set options from config to pass
 -- it into new() function.
 local function parse_params(node)
+    local log_requests = node.log_requests
+    if type(log_requests) == "string" then
+        local level = log_requests:lower()
+        if level == "error" then
+            log_requests = log.error
+        elseif level == "warn" then
+            log_requests = log.warn
+        elseif level == "info" then
+            log_requests = log.info
+        elseif level == "verbose" then
+            log_requests = log.verbose
+        elseif level == "debug" then
+            log_requests = log.debug
+        else
+            error("invalid log_requests: " .. log_requests)
+        end
+    elseif log_requests ~= nil then
+        error("log_requests option should be a string")
+    end
+
     return {
+        log_requests = log_requests,
         ssl_cert_file = node.ssl_cert_file,
         ssl_key_file = node.ssl_key_file,
         ssl_password = node.ssl_password,

--- a/test/unit/httpd_role_test.lua
+++ b/test/unit/httpd_role_test.lua
@@ -209,6 +209,24 @@ local validation_cases = {
         },
         err = "ssl_key_file and ssl_cert_file must be set to enable TLS",
     },
+    ["log_requests_invalid_string"] = {
+        cfg = {
+            server = {
+                listen = "localhost:123",
+                log_requests = "yes",
+            },
+        },
+        err = "invalid log_requests",
+    },
+    ["log_requests_invalid_type"] = {
+        cfg = {
+            server = {
+                listen = "localhost:123",
+                log_requests = 42,
+            },
+        },
+        err = "log_requests option should be a string",
+    }
 }
 
 for name, case in pairs(validation_cases) do
@@ -310,4 +328,27 @@ g.test_edit_server_address = function()
     result = httpd_role.get_server()
     t.assert(result)
     t.assert_equals(result.port, cfg[httpd_role.DEFAULT_SERVER_NAME].listen)
+end
+
+g.test_log_requests = function()
+    local cfg = {
+        server1 = {
+            listen = 13002,
+            log_requests = 'info',
+        },
+        server2 = {
+            listen = 13003,
+            log_requests = 'verbose',
+        },
+    }
+
+    httpd_role.apply(cfg)
+
+    local server1 = httpd_role.get_server('server1')
+    t.assert(server1)
+    t.assert_type(server1.options.log_requests, 'function')
+
+    local server2 = httpd_role.get_server('server2')
+    t.assert(server2)
+    t.assert_type(server2.options.log_requests, 'function')
 end


### PR DESCRIPTION
Currently, HTTP requests are logged at the default level `log.info`, which can create noise (e.g. for metrics endpoints).
This change allows setting custom log levels (e.g. `log.verbose`) for incoming requests.

Example:
```yaml
roles_cfg:
  roles.httpd:
    default:
      listen: 8081
      log_requests: log.verbose
  roles.metrics-export:
    http:
    - endpoints:
      - path: /metrics
        format: prometheus
```

Closes TNTP-3229