### PR TITLE
Release 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## Added
+### Added
+
+### Changed
+
+### Fixed
+
+## [1.9.0] - 2025-11-11
+
+The release introduces a new `ssl_verify_client` option and changes default
+behavior with provided `ca_file` param. Also a few bugs were fixed.
+
+### Added
 
 - `ssl_verify_client` option (#207).
 
-## Changed
-
-## Fixed
+### Fixed
 
 - Do not recreate server if it's address and port were not changed (#219).
 - Server doesn't change after updating parameters on config reload (#216).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ add_custom_target(coverage
 )
 
 if(DEFINED ENV{GITHUB_TOKEN})
-  set(COVERALLS_COMMAND ${LUACOVCOVERALLS} --include ^http --verbose --repo-token $ENV{GITHUB_TOKEN})
+  set(COVERALLS_COMMAND ${LUACOVCOVERALLS} --include ^http --include ^roles --verbose --repo-token $ENV{GITHUB_TOKEN})
 else()
   set(COVERALLS_COMMAND ${CMAKE_COMMAND} -E echo "Skipped uploading to coveralls.io: no token.")
 endif()

--- a/http/version.lua
+++ b/http/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.8.0'
+return '1.9.0'


### PR DESCRIPTION
The release introduces a new `ssl_verify_client` option and changes default behavior with provided `ca_file` param. Also a few bugs was fixed.

## Added

- `ssl_verify_client` option (#207).

## Fixed

- Do not recreate server if it's address and port were not changed (#219).
- Server doesn't change after updating parameters on config reload (#216).
- **Breaking change**: Mutual TLS with `ca_file` option enabled by default (#217).